### PR TITLE
BUGFIX: Make regular expression ungreedy

### DIFF
--- a/Resources/Private/Scripts/App.js
+++ b/Resources/Private/Scripts/App.js
@@ -80,7 +80,7 @@ import '../Styles/Main.scss';
 
                 let pageContent = parsedPreviewDocument.querySelector('body').innerHTML;
 
-                const re = /data-.*=".*"/gim;
+                const re = /data-.*?=".*?"/gim;
                 pageContent = pageContent.replace(re, '');
 
                 // Create snippet preview


### PR DESCRIPTION
The previous regular expression allowed way to large matches and caused empty pages during analysing