### PR TITLE
TASK: Adjust constraint for Neos 4 and rely on Neos.Seo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,8 @@
         }
     ],
     "require": {
-        "neos/neos": "~3.0"
-    },
-    "suggest": {
-        "neos/seo": "~2.0"
+        "neos/neos": "^3.0 || ^4.0 || dev-master",
+        "neos/seo": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since we use the properties of Neos.Seo anyways we can make it a dependency.