### PR TITLE
FEATURE: Cache inspector translations in store

### DIFF
--- a/Resources/Private/Scripts/YoastInfoView/src/actions/index.js
+++ b/Resources/Private/Scripts/YoastInfoView/src/actions/index.js
@@ -1,0 +1,36 @@
+import {createAction} from 'redux-actions';
+import {Map} from 'immutable';
+import {$set} from 'plow-js';
+
+import {handleActions} from '@neos-project/utils-redux';
+import {actionTypes as system} from '@neos-project/neos-ui-redux-store';
+
+const SET_TRANSLATIONS = 'SET_TRANSLATIONS';
+
+//
+// Export the action types
+//
+export const actionTypes = {
+    SET_TRANSLATIONS
+};
+
+const setTranslations = createAction(SET_TRANSLATIONS, translations => translations);
+
+//
+// Export the actions
+//
+export const actions = {
+    setTranslations
+};
+
+//
+// Export the reducer
+//
+export const reducer = handleActions({
+    [system.INIT]: () => $set('ui.yoastInfoView', new Map({
+        translations: {}
+    })),
+    [SET_TRANSLATIONS]: translations => $set('ui.yoastInfoView', new Map({
+        translations: translations
+    }))
+});

--- a/Resources/Private/Scripts/YoastInfoView/src/manifest.js
+++ b/Resources/Private/Scripts/YoastInfoView/src/manifest.js
@@ -1,11 +1,15 @@
 import YoastInfoView from './YoastInfoView';
 
 import manifest from '@neos-project/neos-ui-extensibility';
+import {reducer} from './actions';
 
 manifest('Shel.Neos.YoastSeo:YoastInfoView', {}, globalRegistry => {
     const viewsRegistry = globalRegistry.get('inspector').get('views');
+    const reducersRegistry = globalRegistry.get('reducers');
 
     viewsRegistry.set('Shel.Neos.YoastSeo/Inspector/Views/YoastInfoView', {
         component: YoastInfoView
     });
+
+    reducersRegistry.set('neos-yoast-seo', {reducer: reducer});
 });


### PR DESCRIPTION
This keeps the ui from reloading the translations every time
the yoast inspector module is opened.
But the translations will currently still be reloaded when the
backend is reloaded.

Resolves: #13