### PR TITLE
Correct build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This view is helpful when optimizing a single page while working on it's content
 You can generate the `js` and `css` files by running the following commands in the package folder:
 
     yarn install
-    yarn run build-all
+    yarn run build
     
 #### Building and watchting the app for the edit mode
     

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This view is helpful when optimizing a single page while working on it's content
 
 ### Building the assets
 
-You can generate the `js` and `css` files by running the following commands in the package folder:
+You can generate the `js` and `css` files by running the following commands in the folder `Resources/Private/Scripts/YoastInfoView`:
 
     yarn install
     yarn run build


### PR DESCRIPTION
The build-all command is not there anymore and is now called build.